### PR TITLE
Kibana 7.2 through 7.4 Fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
   "dependencies" : {
     "vis-network": "7.2.0",
     "randomcolor": "0.5.0",
-    "css-element-queries": "0.3.2"
+    "css-element-queries": "0.3.2",
+    "keycharm": "^0.2.0",
+    "moment": "^2.24.0",
+    "vis-data": "^6.3.5",
+    "vis-util": "^1.1.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/dlumbrer/kbn_network"
   },
   "dependencies" : {
-    "vis": "4.16.1",
+    "vis-network": "7.2.0",
     "randomcolor": "0.5.0",
     "css-element-queries": "0.3.2"
   }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "css-element-queries": "0.3.2",
     "keycharm": "^0.2.0",
     "moment": "^2.24.0",
-    "vis-data": "^6.3.5",
+    "vis-data": "^6.2.1",
     "vis-util": "^1.1.8"
   }
 }

--- a/public/network_vis_controller.js
+++ b/public/network_vis_controller.js
@@ -4,7 +4,7 @@ import { uiModules } from 'ui/modules';
 // didn't already
 const module = uiModules.get('kibana/transform_vis', ['kibana']);
 //import the npm modules
-const visN = require('vis');
+const visN = require('vis-network');
 const randomColor = require('randomcolor');
 const ElementQueries = require('css-element-queries/src/ElementQueries');
 const ResizeSensor = require('css-element-queries/src/ResizeSensor');
@@ -153,7 +153,7 @@ module.controller('KbnNetworkVisController', function ($scope, $sce, $timeout, P
                             if (metricsAgg_sizeNode) {
                                 // Use the getValue function of the aggregation to get the value of a bucket
                                 var value = bucket[nodeSizeId]//metricsAgg_sizeNode.getValue(bucket);
-                                var sizeVal = Math.min($scope.vis.params.maxCutMetricSizeNode, value);
+                                var sizeVal = Math.max($scope.vis.params.maxCutMetricSizeNode, value);
 
                                 //No show nodes under the value
                                 if ($scope.vis.params.minCutMetricSizeNode > value) {
@@ -176,7 +176,7 @@ module.controller('KbnNetworkVisController', function ($scope, $sce, $timeout, P
                             if ($scope.vis.aggs.bySchemaName['first'].length > 1) {
                                 if (metricsAgg_sizeEdge) {
                                     var value_sizeEdge = bucket[edgeSizeId];
-                                    var sizeEdgeVal = Math.min($scope.vis.params.maxCutMetricSizeEdge, value_sizeEdge);
+                                    var sizeEdgeVal = Math.max($scope.vis.params.maxCutMetricSizeEdge, value_sizeEdge);
                                 } else {
                                     var sizeEdgeVal = 0.1;
                                 }
@@ -252,7 +252,7 @@ module.controller('KbnNetworkVisController', function ($scope, $sce, $timeout, P
                             if ($scope.vis.aggs.bySchemaName['first'].length > 1) {
                                 if (metricsAgg_sizeEdge) {
                                     var value_sizeEdge = bucket[edgeSizeId];
-                                    var sizeEdgeVal = Math.min($scope.vis.params.maxCutMetricSizeEdge, value_sizeEdge);
+                                    var sizeEdgeVal = Math.max($scope.vis.params.maxCutMetricSizeEdge, value_sizeEdge);
                                 } else {
                                     var sizeEdgeVal = 0.1;
                                 }
@@ -496,7 +496,7 @@ module.controller('KbnNetworkVisController', function ($scope, $sce, $timeout, P
                             if (metricsAgg_sizeNode) {
                                 // Use the getValue function of the aggregation to get the value of a bucket
                                 var value = bucket[nodeSizeId];
-                                var sizeVal = Math.min($scope.vis.params.maxCutMetricSizeNode, value);
+                                var sizeVal = Math.max($scope.vis.params.maxCutMetricSizeNode, value);
 
                                 //No show nodes under the value
                                 if ($scope.vis.params.minCutMetricSizeNode > value) {
@@ -515,7 +515,7 @@ module.controller('KbnNetworkVisController', function ($scope, $sce, $timeout, P
                             //RELATION//////////////////////////////
                             if (metricsAgg_sizeEdge) {
                                 var value_sizeEdge = bucket[edgeSizeId];
-                                var sizeEdgeVal = Math.min($scope.vis.params.maxCutMetricSizeEdge, value_sizeEdge);
+                                var sizeEdgeVal = Math.max($scope.vis.params.maxCutMetricSizeEdge, value_sizeEdge);
                             } else {
                                 var sizeEdgeVal = 0.1;
                             }
@@ -588,7 +588,7 @@ module.controller('KbnNetworkVisController', function ($scope, $sce, $timeout, P
                             if ($scope.vis.aggs.bySchemaName['second'].length > 0) {
                                 if (metricsAgg_sizeEdge) {
                                     var value_sizeEdge = bucket[edgeSizeId];
-                                    var sizeEdgeVal = Math.min($scope.vis.params.maxCutMetricSizeEdge, value_sizeEdge);
+                                    var sizeEdgeVal = Math.max($scope.vis.params.maxCutMetricSizeEdge, value_sizeEdge);
                                 } else {
                                     var sizeEdgeVal = 0.1;
                                 }


### PR DESCRIPTION
* Replace deprecated vis library
Almende/vis is at end of life and also produced this [bug](https://github.com/almende/vis/issues/3899)
visjs/vis-network is actively developed, uses the same API, and only needed to be imported 

* Fix "Top Values" selection for node/edge bucketing and sizing.
We often have large data results being returned for aggregations (greater than the default 5000), and Math.min is being used to choose between the default 5000 or the maxCutMetricSize returned by our results. This results in 5000 being used as the top value for node/edge size, which makes any results above that appear to be equally sized. For example, using `Count` on a Field like `SrcIP` could return IP addresses with 20,000, 10,000, and 5,000 hits in our data set, which would all be equally sized as large nodes. This PR switches Math.min to Math.max.
